### PR TITLE
build(deps): bump tools version to v6 / 8092744

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8496,8 +8496,8 @@ var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _argume
 
 
 
-const CMDLINE_TOOLS_VERSION = '3.0';
-const COMMANDLINE_TOOLS_VERSION = '6858069';
+const CMDLINE_TOOLS_VERSION = '6.0';
+const COMMANDLINE_TOOLS_VERSION = '8092744';
 const COMMANDLINE_TOOLS_WIN_URL = `https://dl.google.com/android/repository/commandlinetools-win-${COMMANDLINE_TOOLS_VERSION}_latest.zip`;
 const COMMANDLINE_TOOLS_MAC_URL = `https://dl.google.com/android/repository/commandlinetools-mac-${COMMANDLINE_TOOLS_VERSION}_latest.zip`;
 const COMMANDLINE_TOOLS_LIN_URL = `https://dl.google.com/android/repository/commandlinetools-linux-${COMMANDLINE_TOOLS_VERSION}_latest.zip`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,8 @@ import * as fs from 'fs'
 import * as fse from 'fs-extra'
 import * as os from 'os'
 
-const CMDLINE_TOOLS_VERSION = '3.0'
-const COMMANDLINE_TOOLS_VERSION = '6858069'
+const CMDLINE_TOOLS_VERSION = '6.0'
+const COMMANDLINE_TOOLS_VERSION = '8092744'
 
 const COMMANDLINE_TOOLS_WIN_URL = `https://dl.google.com/android/repository/commandlinetools-win-${COMMANDLINE_TOOLS_VERSION}_latest.zip`
 const COMMANDLINE_TOOLS_MAC_URL = `https://dl.google.com/android/repository/commandlinetools-mac-${COMMANDLINE_TOOLS_VERSION}_latest.zip`


### PR DESCRIPTION

Hi there!

Just wanted to post a PR that bumps this to the latest version:

https://developer.android.com/studio

![image](https://user-images.githubusercontent.com/782704/164545766-316f6057-5cef-47dc-bdbf-5afce7c11456.png)
