### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ steps:
 - name: Set up JDK 1.8
   uses: actions/setup-java@v3
   with:
-    java-version: 1.8
+    java-version: '17'
+    distribution: 'temurin'
 
 - name: Setup Android SDK
   uses: android-actions/setup-android@v2


### PR DESCRIPTION
The README action as written fails because `distribution` is a required parameter now. It also failed to install "1.7" but works with "17"

```
2023-06-01T15:17:57.9161030Z ##[error]Could not find satisfied version for SemVer '1.8'. 
Available versions: 20.0.1+9, 20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9, 18.0.1+10, 18.0.0+36, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7, 17.0.2+8, 17.0.1+12, 17.0.0+35, 16.0.2+7, 11.0.19+7, 11.0.18+10, 11.0.17+8, 11.0.16+101, 11.0.16+8, 11.0.15+10, 11.0.14+101, 11.0.14+9, 11.0.13+8, 11.0.12+7, 8.0.372+7, 8.0.362+9, 8.0.352+8, 8.0.345+1, 8.0.342+7, 8.0.332+9, 8.0.322+6, 8.0.312+7, 8.0.302+8
```