### PR TITLE
Add support for 11076708 (12.0)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -67,6 +67,7 @@ jobs:
           - windows-2022
           - windows-2019
         cmdline-tools-version:
+          - 11076708
           - 10406996
           - 9862592
           - 9477386

--- a/dist/index.js
+++ b/dist/index.js
@@ -28824,6 +28824,8 @@ const fs = __importStar(__nccwpck_require__(7147));
 const os = __importStar(__nccwpck_require__(2037));
 function getVersionShort(versionLong) {
     switch (versionLong) {
+        case '11076708':
+            return '12.0';
         case '10406996':
             return '11.0';
         case '9862592':

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,8 @@ import * as os from 'os'
 
 function getVersionShort(versionLong: string): string {
   switch (versionLong) {
+    case '11076708':
+      return '12.0'
     case '10406996':
       return '11.0'
     case '9862592':


### PR DESCRIPTION
Bumping to latest command line tool. Note that the default version is not changed to not do any unexpected changes.