### PR TITLE
Maintain GHA runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -60,12 +60,11 @@ jobs:
         os:
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
+          - macos-26
+          - macos-15
           - macos-14
-          - macos-13
-          - macos-12
+          - windows-2025
           - windows-2022
-          - windows-2019
         cmdline-tools-version:
           - 12266719
           - 11479570


### PR DESCRIPTION
| Runner | Status | Details |
|---|---|---|
| `ubuntu-24.04` | ✅ Available | [Available Images](https://github.com/actions/runner-images#available-images) |
| `ubuntu-22.04` | ✅ Available | [Available Images](https://github.com/actions/runner-images#available-images) |
| `ubuntu-20.04` | ❌ Removed April 15, 2025 | [GitHub Blog](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), [runner-images#11101](https://github.com/actions/runner-images/issues/11101) |
| `macos-26` | :star: New | [Available Images](https://github.com/actions/runner-images#available-images) |
| `macos-15` | :star: New | [Available Images](https://github.com/actions/runner-images#available-images) |
| `macos-14` | ✅ Available | [Available Images](https://github.com/actions/runner-images#available-images) |
| `macos-13` | ❌ Removed December 4, 2025 | [GitHub Blog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), [runner-images#13046](https://github.com/actions/runner-images/issues/13046) |
| `macos-12` | ❌ Removed December 3, 2024 | [runner-images#10721](https://github.com/actions/runner-images/issues/10721) |
| `windows-2025` | :star: New | [Available Images](https://github.com/actions/runner-images#available-images) |
| `windows-2022` | ✅ Available | [Available Images](https://github.com/actions/runner-images#available-images) |
| `windows-2019` | ❌ Removed June 30, 2025 | [GitHub Blog](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/), [runner-images#12045](https://github.com/actions/runner-images/issues/12045) |

Test: https://github.com/TWiStErRob/setup-android/pull/2

## WHy?

<img width="270" height="1592" alt="image" src="https://github.com/user-attachments/assets/f1a35ee1-2f51-449b-b0bc-67f9c1940105" />
